### PR TITLE
Add support for nix flakes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1695830400,
+        "narHash": "sha256-gToZXQVr0G/1WriO83olnqrLSHF2Jb8BPcmCt497ro0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8a86b98f0ba1c405358f1b71ff8b5e1d317f5db2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,37 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+
+  flake-utils.lib.eachDefaultSystem (system: let 
+    pkgs = import nixpkgs { inherit system; };
+    version = "1.2.1";
+  in  {
+    packages.default = pkgs.stdenv.mkDerivation {
+      pname = "awktc";
+      inherit version;
+      src = pkgs.fetchFromGitHub {
+        owner = "mikkun";
+        repo = "AWKTC";
+        rev = "v${version}";
+        hash = "sha256-m6CsdtuUtUUtjhzs0rKXp+1A2KQgJtBaWnK2pK8L/rc=";
+      };
+
+      nativeBuildInputs = builtins.attrValues { inherit (pkgs) makeWrapper; };
+      buildInputs = builtins.attrValues { inherit (pkgs) gawk; };
+
+      installPhase = ''
+        install -Dm 755 "awktc.awk" "$out/bin/awktc"
+      '';
+
+      postFixup = ''
+        wrapProgram "$out/bin/awktc" \
+          --set PATH ${pkgs.lib.makeBinPath [ pkgs.coreutils pkgs.gawk ]};
+      '';
+    };
+  });
+}
+

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
 
   outputs = { self, nixpkgs, flake-utils }:
 
-  flake-utils.lib.eachSystem flake-utils.lib.allSystems (system: let 
+  with flake-utils.lib; eachSystem allSystems (system: let 
     pkgs = import nixpkgs { inherit system; };
     version = "1.2.1";
   in  {

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
 
   outputs = { self, nixpkgs, flake-utils }:
 
-  flake-utils.lib.eachDefaultSystem (system: let 
+  flake-utils.lib.eachSystem flake-utils.lib.allSystems (system: let 
     pkgs = import nixpkgs { inherit system; };
     version = "1.2.1";
   in  {


### PR DESCRIPTION
This allows for users running nix flakes to run AWKTC with the command `nix run github:mikkun/AWKTC`

### Changes
 * Added the flake.nix and flake.lock files to support for running awktc using nix flakes.